### PR TITLE
Gemfile.lock fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     pg (1.3.5)
     public_suffix (4.0.7)
     puma (5.6.4)
@@ -180,6 +182,8 @@ GEM
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.1.0)
       ffi (~> 1.9)
+    sassc (2.1.0-x86_64-linux)
+      ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -228,6 +232,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
### 概要
herokuデプロイ時に、`Failed to install gems via Bundler.` エラーが出たため`bundle lock --add-platform x86_64-linux`　　を実行した。